### PR TITLE
Add Eclipse Java project structure

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+    <classpathentry kind="src" path="src"/>
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+    <classpathentry kind="output" path="bin"/>
+</classpath>

--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+    <name>GitCodeQuality</name>
+    <comment></comment>
+    <projects>
+    </projects>
+    <buildSpec>
+        <buildCommand>
+            <name>org.eclipse.jdt.core.javabuilder</name>
+            <arguments>
+            </arguments>
+        </buildCommand>
+    </buildSpec>
+    <natures>
+        <nature>org.eclipse.jdt.core.javanature</nature>
+    </natures>
+</projectDescription>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # GitCodeQuality
+
+This repository contains a basic Eclipse Java project.

--- a/src/Main.java
+++ b/src/Main.java
@@ -1,0 +1,5 @@
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello, Eclipse!");
+    }
+}


### PR DESCRIPTION
## Summary
- create `.project` and `.classpath` for a standard Eclipse Java project
- add `src/Main.java` with a simple main method
- fix README to describe the project

## Testing
- `javac src/Main.java`

------
https://chatgpt.com/codex/tasks/task_e_687dee76e4c88328b3be1e6a9b288cca